### PR TITLE
Simple SELECT queries generation

### DIFF
--- a/generators/base/base.go
+++ b/generators/base/base.go
@@ -37,6 +37,10 @@ const (
 
 	// custom types flag
 	customTypesFlag = "custom-types"
+
+	// generate simple ORM queries
+	genORM = "gen-orm"
+	dbWrap = "db-wrap"
 )
 
 // Gen is interface for all generators
@@ -69,6 +73,12 @@ type Options struct {
 
 	// Custom types goes here
 	CustomTypes model.CustomTypeMapping
+
+	// Generate basic ORM queries
+	GenORM bool
+
+	// Struct name for ORM queries. Works only when GenORM == true
+	DBWrapName string
 }
 
 // Def sets default options if empty
@@ -117,11 +127,14 @@ func AddFlags(command *cobra.Command) {
 
 	flags.StringSlice(customTypesFlag, []string{}, "set custom types separated by comma\nformat: <postgresql_type>:<go_import>.<go_type>\nexamples: uuid:github.com/google/uuid.UUID,point:src/model.Point,bytea:string\n")
 
+	flags.BoolP(genORM, "q", false, "generate basic ORM queries")
+	flags.StringP(dbWrap, "z", "DatabaseWrap", "name of structs for wrapping ORM queries (works only with flag -q, --gen-orm)")
+
 	return
 }
 
 // ReadFlags reads basic flags from command
-func ReadFlags(command *cobra.Command) (conn, output, pkg string, tables []string, followFKs bool, customTypes model.CustomTypeMapping, err error) {
+func ReadFlags(command *cobra.Command) (conn, output, pkg string, tables []string, followFKs bool, genOrm bool, dbWrapName string, customTypes model.CustomTypeMapping, err error) {
 	var customTypesStrings []string
 	uuid := false
 
@@ -148,6 +161,13 @@ func ReadFlags(command *cobra.Command) (conn, output, pkg string, tables []strin
 	}
 
 	if followFKs, err = flags.GetBool(FollowFKs); err != nil {
+		return
+	}
+
+	if genOrm, err = flags.GetBool(genORM); err != nil {
+		return
+	}
+	if dbWrapName, err = flags.GetString(dbWrap); err != nil {
 		return
 	}
 

--- a/generators/model/generator.go
+++ b/generators/model/generator.go
@@ -62,7 +62,7 @@ func (g *Basic) AddFlags(command *cobra.Command) {
 func (g *Basic) ReadFlags(command *cobra.Command) error {
 	var err error
 
-	g.options.URL, g.options.Output, g.options.Package, g.options.Tables, g.options.FollowFKs, g.options.CustomTypes, err = base.ReadFlags(command)
+	g.options.URL, g.options.Output, g.options.Package, g.options.Tables, g.options.FollowFKs, g.options.GenORM, g.options.DBWrapName, g.options.CustomTypes, err = base.ReadFlags(command)
 	if err != nil {
 		return err
 	}

--- a/generators/model/generator_test.go
+++ b/generators/model/generator_test.go
@@ -17,6 +17,8 @@ func TestGenerator_Generate(t *testing.T) {
 	generator.options.URL = `postgres://some_user:some_password@localhost:5432/some_db?sslmode=disable`
 	generator.options.Output = path.Join(os.TempDir(), "model_test.go")
 	generator.options.FollowFKs = true
+	generator.options.GenORM = true
+	generator.options.DBWrapName = "MyCustomWrapper"
 	generator.options.CustomTypes.Add(model.TypePGUuid, "uuid.UUID", "github.com/google/uuid")
 	//generator.options.AddJSONTag = true
 

--- a/generators/model/generator_test.output
+++ b/generators/model/generator_test.output
@@ -115,3 +115,57 @@ type GeoCountry struct {
 	Code   string `bun:"code,nullzero"`
 	Coords []int  `bun:"coords,array"`
 }
+
+/* Common ORM queries */
+
+// Just a wrapper around database connection
+type MyCustomWrapper struct {
+	*bun.DB
+}
+
+/* 'SELECT' queries */
+func (dbConn *MyCustomWrapper) SelectProject() ([]*Project, error) {
+	ctx := context.Background()
+	model := []*Project{}
+
+	err := dbConn.NewSelect().
+		Column("t.projectId").
+		Column("t.code").
+		Column("t.name").
+		Model(&model).
+		Scan(ctx)
+	return model, err
+}
+
+func (dbConn *MyCustomWrapper) SelectUser() ([]*User, error) {
+	ctx := context.Background()
+	model := []*User{}
+
+	err := dbConn.NewSelect().
+		Column("t.userId").
+		Column("t.email").
+		Column("t.activated").
+		Column("t.name").
+		Column("t.countryId").
+		Column("t.avatar").
+		Column("t.avatarAlt").
+		Column("t.apiKeys").
+		Column("t.loggedAt").
+		Model(&model).
+		Scan(ctx)
+	return model, err
+}
+
+func (dbConn *MyCustomWrapper) SelectGeoCountry() ([]*GeoCountry, error) {
+	ctx := context.Background()
+	model := []*GeoCountry{}
+
+	err := dbConn.NewSelect().
+		Column("t.countryId").
+		Column("t.code").
+		Column("t.coords").
+		Model(&model).
+		Scan(ctx)
+	return model, err
+}
+

--- a/generators/model/model.go
+++ b/generators/model/model.go
@@ -17,6 +17,9 @@ type TemplatePackage struct {
 	Imports    []string
 
 	Entities []TemplateEntity
+
+	ORMNeeded   bool
+	ORMDbStruct string
 }
 
 // NewTemplatePackage creates a package for template
@@ -38,7 +41,9 @@ func NewTemplatePackage(entities []model.Entity, options Options) TemplatePackag
 		HasImports: imports.Len() > 0,
 		Imports:    imports.Elements(),
 
-		Entities: models,
+		Entities:    models,
+		ORMNeeded:   options.GenORM,
+		ORMDbStruct: options.DBWrapName,
 	}
 }
 

--- a/generators/search/generator.go
+++ b/generators/search/generator.go
@@ -58,7 +58,7 @@ func (g *Search) AddFlags(command *cobra.Command) {
 func (g *Search) ReadFlags(command *cobra.Command) error {
 	var err error
 
-	g.options.URL, g.options.Output, g.options.Package, g.options.Tables, g.options.FollowFKs, g.options.CustomTypes, err = base.ReadFlags(command)
+	g.options.URL, g.options.Output, g.options.Package, g.options.Tables, g.options.FollowFKs, _, _, g.options.CustomTypes, err = base.ReadFlags(command)
 	if err != nil {
 		return err
 	}

--- a/generators/validate/generator.go
+++ b/generators/validate/generator.go
@@ -49,7 +49,7 @@ func (g *Validate) AddFlags(command *cobra.Command) {
 func (g *Validate) ReadFlags(command *cobra.Command) error {
 	var err error
 
-	g.options.URL, g.options.Output, g.options.Package, g.options.Tables, g.options.FollowFKs, g.options.CustomTypes, err = base.ReadFlags(command)
+	g.options.URL, g.options.Output, g.options.Package, g.options.Tables, g.options.FollowFKs, _, _, g.options.CustomTypes, err = base.ReadFlags(command)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Work on #3
Added two new flags:
* `q` - for initialization of process for ORM queries generation
* `z` - for providing custom Go's struct name for ORM Executor (which is *bun.DB basically)
Works for `model` only (currently)